### PR TITLE
🚀 1단계 - DI 컨테이너 구현하기, 🚀 2단계 - DI 컨테이너 구현하기(힌트)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,36 @@
 ## 1단계 요구사항
 - [x] 사전 요구사항 1 - 학습테스트를 진행한다.
 - [] 요구사항 1 - DefaultListableBeanFactoryTest 가 통과하게 만든다.
-    - @Controller, @Service, @Repository를 스캔해서 클래스들을 가져온다.
+    - @Controller, @Service, @Repository를 스캔해서 클래스들을 가져온다. (BeanScanner)
       - 기능 
       - 조건 
-    - @Autowired을 사용한 생성자를 이용해서 의존관계를 생성한다.
+    - @Autowired을 사용한 생성자를 이용해서 의존관계를 생성한다. (BeanFactory)
       - 기능
       - 조건
 - [] 요구사항 2 - AnnotationMapping이 동작하도록 리팩터링한다.
     - BeanFactory와 BeanScanner를 잘 활용해서 동작하면 된다.
       
+- [] 공통 요구사항
+  - [] DefaultListableBean이 Bean 조립 즉, Injection을 책임으로 가진 구현체이다. 책임에 맞게 클래스 설계하라 
+    - doResolveDependency(Dependency-descriptor, beanName)  (의존 관계에 대한 descriptor, bean 이름을 가지고 주입해준다.)
+      - findAutowireCandidates(qualifier를 가지고 주입하게된다.)
+      - ConstructorResolver를 통해 injectionPoint를 가지고 bean 주입을 하게된다. 
+  - [] BeanScanner 는 Bean을 scan 만하는 책임을 가진다.
+  - [] BeanDefinitionRegistry 에서 bean을 등록하는 책임을 가진다. (BeanDefinitionMap에 넣어준다. beanName, beanDefinition)
+  - [] BeanDefinition은 instance 에 대한 정보를 담는다 + scope
+
+- [] 요구사항 분석
+- 호출 순서
+    - ApplicationContext -> DefaultListableBeanFactory(Scanner)
+    - scaner 호출로 registry에 bean definition 등록
+    - beanfactory.initialize로 객체들 definition에 맞게 구현체 생성
+    - ApplicationContext 반환
+- DefaultListableBean (BeanDefinitionRegistry 인터페이스, )
+  - beanDefinitionMap (beanName, beanDefinition) 해쉬맵
+  - singletonObjects (clazz, 구현체들) 해쉬맵
+- 라이프사이클
+  - REGISTRY 등록 
+  - initialize 하면 Registry에서 BeanDefinition을 읽어서 instance 생성하는 방향이다.
+    - injector를 확인해보고 다른 의존관계를 getBean으로 가져오는데 없다면 생성하면된다. 
+
+

--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@
 
 ### 프로토타입 스코프
 <img src="docs/images/prototype.png" alt="prototype">
+
+## 1단계 요구사항
+- [x] 사전 요구사항 1 - 학습테스트를 진행한다.
+- [] 요구사항 1 - DefaultListableBeanFactoryTest 가 통과하게 만든다.
+    - @Controller, @Service, @Repository를 스캔해서 클래스들을 가져온다.
+      - 기능 
+      - 조건 
+    - @Autowired을 사용한 생성자를 이용해서 의존관계를 생성한다.
+      - 기능
+      - 조건
+- [] 요구사항 2 - AnnotationMapping이 동작하도록 리팩터링한다.
+    - BeanFactory와 BeanScanner를 잘 활용해서 동작하면 된다.
+      

--- a/README.md
+++ b/README.md
@@ -37,24 +37,20 @@
 
 ## 1단계 요구사항
 - [x] 사전 요구사항 1 - 학습테스트를 진행한다.
-- [] 요구사항 1 - DefaultListableBeanFactoryTest 가 통과하게 만든다.
-    - @Controller, @Service, @Repository를 스캔해서 클래스들을 가져온다. (BeanScanner)
-      - 기능 
-      - 조건 
+- [x] 요구사항 1 - DefaultListableBeanFactoryTest 가 통과하게 만든다.
+    - @Controller, @Service, @Repository를 스캔해서 클래스들을 가져온다. (BeanScanner) 
     - @Autowired을 사용한 생성자를 이용해서 의존관계를 생성한다. (BeanFactory)
-      - 기능
-      - 조건
-- [] 요구사항 2 - AnnotationMapping이 동작하도록 리팩터링한다.
+- [x] 요구사항 2 - AnnotationMapping이 동작하도록 리팩터링한다.
     - BeanFactory와 BeanScanner를 잘 활용해서 동작하면 된다.
       
-- [] 공통 요구사항
-  - [] DefaultListableBean이 Bean 조립 즉, Injection을 책임으로 가진 구현체이다. 책임에 맞게 클래스 설계하라 
+- [x] 공통 요구사항
+  - [x] DefaultListableBean이 Bean 조립 즉, Injection을 책임으로 가진 구현체이다. 책임에 맞게 클래스 설계하라 
     - doResolveDependency(Dependency-descriptor, beanName)  (의존 관계에 대한 descriptor, bean 이름을 가지고 주입해준다.)
       - findAutowireCandidates(qualifier를 가지고 주입하게된다.)
       - ConstructorResolver를 통해 injectionPoint를 가지고 bean 주입을 하게된다. 
-  - [] BeanScanner 는 Bean을 scan 만하는 책임을 가진다.
-  - [] BeanDefinitionRegistry 에서 bean을 등록하는 책임을 가진다. (BeanDefinitionMap에 넣어준다. beanName, beanDefinition)
-  - [] BeanDefinition은 instance 에 대한 정보를 담는다 + scope
+  - [x] BeanScanner 는 Bean을 scan 하고 registerBean하는 책임을 가진다.
+  - [x] BeanDefinitionRegistry 에서 등록된 bean을 반환 책임을 가진다. (BeanDefinitionMap에 넣어준다. beanName, beanDefinition)
+  - [x] BeanDefinition은 instance 에 대한 정보를 담는다 + scope
 
 - [] 요구사항 분석
 - 호출 순서

--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@
 - [] @Autowired 검사
 - [x] fields 주입 안하면 삭제
 - [] DefaultInjector 생성하지 않고 전달 방법 확인
-- [] @Component를 가진 애노테이션을 스캔하는 메서드를 분리해서 가독성 늘리기
+- [x] @Component를 가진 애노테이션을 스캔하는 메서드를 분리해서 가독성 늘리기
 

--- a/README.md
+++ b/README.md
@@ -67,3 +67,9 @@
     - injector를 확인해보고 다른 의존관계를 getBean으로 가져오는데 없다면 생성하면된다. 
 
 
+## 피드백 사항
+- [] @Autowired 검사
+- [x] fields 주입 안하면 삭제
+- [] DefaultInjector 생성하지 않고 전달 방법 확인
+- [] @Component를 가진 애노테이션을 스캔하는 메서드를 분리해서 가독성 늘리기
+

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 
 
 ## 피드백 사항
-- [] @Autowired 검사
+- [x] @Autowired 검사
 - [x] fields 주입 안하면 삭제
 - [] DefaultInjector 생성하지 않고 전달 방법 확인
 - [x] @Component를 가진 애노테이션을 스캔하는 메서드를 분리해서 가독성 늘리기

--- a/di/src/main/java/com/interface21/beans/factory/annotation/Autowired.java
+++ b/di/src/main/java/com/interface21/beans/factory/annotation/Autowired.java
@@ -1,9 +1,15 @@
 package com.interface21.beans.factory.annotation;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD,
+    ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Autowired {
+
 }

--- a/di/src/main/java/com/interface21/beans/factory/config/BeanDefinition.java
+++ b/di/src/main/java/com/interface21/beans/factory/config/BeanDefinition.java
@@ -1,8 +1,12 @@
 package com.interface21.beans.factory.config;
 
+import com.interface21.beans.factory.support.injector.InjectorConsumer;
+
 public interface BeanDefinition {
 
     Class<?> getType();
 
     String getBeanClassName();
+
+    InjectorConsumer<?> getInjector();
 }

--- a/di/src/main/java/com/interface21/beans/factory/config/DefaultBeanDefintion.java
+++ b/di/src/main/java/com/interface21/beans/factory/config/DefaultBeanDefintion.java
@@ -13,12 +13,14 @@ public class DefaultBeanDefintion implements BeanDefinition {
 
     private final Class<?> bean;
     private final List<InjectorConsumer<?>> injectors;
+    private final InjectorConsumer<Object> defaultInjector;
 
     public DefaultBeanDefintion(Class<?> beanClazz) {
         this.bean = beanClazz;
         Constructor<? extends Constructor> constructor = BeanFactoryUtils.getInjectedConstructor(
             beanClazz);
         this.injectors = InjectorConsumerConfig.injectorSuppliers(constructor);
+        this.defaultInjector = new DefaultInjector(bean);
     }
 
     @Override
@@ -36,7 +38,7 @@ public class DefaultBeanDefintion implements BeanDefinition {
         return injectors.stream()
             .filter(InjectorConsumer::support)
             .findFirst()
-            .orElse(new DefaultInjector(bean));
+            .orElse(defaultInjector);
     }
 
 }

--- a/di/src/main/java/com/interface21/beans/factory/config/DefaultBeanDefintion.java
+++ b/di/src/main/java/com/interface21/beans/factory/config/DefaultBeanDefintion.java
@@ -18,9 +18,7 @@ public class DefaultBeanDefintion implements BeanDefinition {
         this.bean = beanClazz;
         Constructor<? extends Constructor> constructor = BeanFactoryUtils.getInjectedConstructor(
             beanClazz);
-        Set<Field> fields = BeanFactoryUtils.getInjectedFields(beanClazz);
-
-        this.injectors = InjectorConsumerConfig.injectorSuppliers(constructor, fields);
+        this.injectors = InjectorConsumerConfig.injectorSuppliers(constructor);
     }
 
     @Override

--- a/di/src/main/java/com/interface21/beans/factory/config/DefaultBeanDefintion.java
+++ b/di/src/main/java/com/interface21/beans/factory/config/DefaultBeanDefintion.java
@@ -1,0 +1,44 @@
+package com.interface21.beans.factory.config;
+
+import com.interface21.beans.factory.support.BeanFactoryUtils;
+import com.interface21.beans.factory.support.injector.DefaultInjector;
+import com.interface21.beans.factory.support.injector.InjectorConsumer;
+import com.interface21.beans.factory.support.injector.InjectorConsumerConfig;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+
+public class DefaultBeanDefintion implements BeanDefinition {
+
+    private final Class<?> bean;
+    private final List<InjectorConsumer<?>> injectors;
+
+    public DefaultBeanDefintion(Class<?> beanClazz) {
+        this.bean = beanClazz;
+        Constructor<? extends Constructor> constructor = BeanFactoryUtils.getInjectedConstructor(
+            beanClazz);
+        Set<Field> fields = BeanFactoryUtils.getInjectedFields(beanClazz);
+
+        this.injectors = InjectorConsumerConfig.injectorSuppliers(constructor, fields);
+    }
+
+    @Override
+    public Class<?> getType() {
+        return bean;
+    }
+
+    @Override
+    public String getBeanClassName() {
+        return bean.getName();
+    }
+
+    @Override
+    public InjectorConsumer<?> getInjector() {
+        return injectors.stream()
+            .filter(InjectorConsumer::support)
+            .findFirst()
+            .orElse(new DefaultInjector(bean));
+    }
+
+}

--- a/di/src/main/java/com/interface21/beans/factory/support/BeanDefinitionReader.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/BeanDefinitionReader.java
@@ -1,5 +1,6 @@
 package com.interface21.beans.factory.support;
 
 public interface BeanDefinitionReader {
+
     void loadBeanDefinitions(Class<?>... annotatedClasses);
 }

--- a/di/src/main/java/com/interface21/beans/factory/support/BeanDefinitionRegistry.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/BeanDefinitionRegistry.java
@@ -3,5 +3,6 @@ package com.interface21.beans.factory.support;
 import com.interface21.beans.factory.config.BeanDefinition;
 
 public interface BeanDefinitionRegistry {
+
     void registerBeanDefinition(Class<?> clazz, BeanDefinition beanDefinition);
 }

--- a/di/src/main/java/com/interface21/beans/factory/support/BeanFactoryUtils.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/BeanFactoryUtils.java
@@ -1,10 +1,6 @@
 package com.interface21.beans.factory.support;
 
 import com.interface21.beans.factory.annotation.Autowired;
-import org.reflections.ReflectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -12,29 +8,35 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.Set;
+import org.reflections.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BeanFactoryUtils {
 
     private static final Logger log = LoggerFactory.getLogger(BeanFactoryUtils.class);
 
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings({"unchecked"})
     public static Set<Method> getInjectedMethods(Class<?> clazz) {
-        return ReflectionUtils.getAllMethods(clazz, ReflectionUtils.withAnnotation(Autowired.class), ReflectionUtils.withReturnType(void.class));
+        return ReflectionUtils.getAllMethods(clazz, ReflectionUtils.withAnnotation(Autowired.class),
+            ReflectionUtils.withReturnType(void.class));
     }
 
-    @SuppressWarnings({ "unchecked" })
-    public static Set<Method> getBeanMethods(Class<?> clazz, Class<? extends Annotation> annotation) {
+    @SuppressWarnings({"unchecked"})
+    public static Set<Method> getBeanMethods(Class<?> clazz,
+        Class<? extends Annotation> annotation) {
         return ReflectionUtils.getAllMethods(clazz, ReflectionUtils.withAnnotation(annotation));
     }
 
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings({"unchecked"})
     public static Set<Field> getInjectedFields(Class<?> clazz) {
         return ReflectionUtils.getAllFields(clazz, ReflectionUtils.withAnnotation(Autowired.class));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public static Set<Constructor> getInjectedConstructors(Class<?> clazz) {
-        return ReflectionUtils.getAllConstructors(clazz, ReflectionUtils.withAnnotation(Autowired.class));
+        return ReflectionUtils.getAllConstructors(clazz,
+            ReflectionUtils.withAnnotation(Autowired.class));
     }
 
     public static Optional<Object> invokeMethod(Method method, Object bean, Object[] args) {
@@ -48,14 +50,15 @@ public class BeanFactoryUtils {
 
     /**
      * 인자로 전달하는 클래스의 생성자 중 @Inject 애노테이션이 설정되어 있는 생성자를 반환
-     * 
-     * @Inject 애노테이션이 설정되어 있는 생성자는 클래스당 하나로 가정한다.
+     *
      * @param clazz
      * @return
+     * @Inject 애노테이션이 설정되어 있는 생성자는 클래스당 하나로 가정한다.
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static Constructor<?> getInjectedConstructor(Class<?> clazz) {
-        Set<Constructor> injectedConstructors = ReflectionUtils.getAllConstructors(clazz, ReflectionUtils.withAnnotation(Autowired.class));
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static Constructor<? extends Constructor> getInjectedConstructor(Class<?> clazz) {
+        Set<Constructor> injectedConstructors = ReflectionUtils.getAllConstructors(clazz,
+            ReflectionUtils.withAnnotation(Autowired.class));
         if (injectedConstructors.isEmpty()) {
             return null;
         }
@@ -63,14 +66,15 @@ public class BeanFactoryUtils {
     }
 
     /**
-     * 인자로 전달되는 클래스의 구현 클래스. 만약 인자로 전달되는 Class가 인터페이스가 아니면 전달되는 인자가 구현 클래스,
-     * 인터페이스인 경우 BeanFactory가 관리하는 모든 클래스 중에 인터페이스를 구현하는 클래스를 찾아 반환
-     * 
+     * 인자로 전달되는 클래스의 구현 클래스. 만약 인자로 전달되는 Class가 인터페이스가 아니면 전달되는 인자가 구현 클래스, 인터페이스인 경우 BeanFactory가
+     * 관리하는 모든 클래스 중에 인터페이스를 구현하는 클래스를 찾아 반환
+     *
      * @param injectedClazz
      * @param preInstanticateBeans
      * @return
      */
-    public static Optional<Class<?>> findConcreteClass(Class<?> injectedClazz, Set<Class<?>> preInstanticateBeans) {
+    public static Optional<Class<?>> findConcreteClass(Class<?> injectedClazz,
+        Set<Class<?>> preInstanticateBeans) {
         if (!injectedClazz.isInterface()) {
             return Optional.of(injectedClazz);
         }

--- a/di/src/main/java/com/interface21/beans/factory/support/BeanScanner.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/BeanScanner.java
@@ -1,0 +1,37 @@
+package com.interface21.beans.factory.support;
+
+import com.interface21.beans.factory.config.DefaultBeanDefintion;
+import com.interface21.context.stereotype.Component;
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.reflections.Reflections;
+
+public class BeanScanner implements Scanner<Object> {
+
+    private final BeanDefinitionRegistry registry;
+
+    public BeanScanner(BeanDefinitionRegistry registry) {
+
+        this.registry = registry;
+    }
+
+    @Override
+    public void scan(Object... basePackage) {
+        Reflections reflections = new Reflections("com.interface21.context");
+        Set<Class<?>> annotatedClasses = reflections.getTypesAnnotatedWith(Component.class);
+        Set<Class<?>> annotations = annotatedClasses.stream()
+            .filter(Class::isAnnotation)
+            .collect(Collectors.toSet());
+
+        Reflections beanScanner = new Reflections(basePackage);
+        for (Class<?> subType : annotations) {
+            beanScanner.getTypesAnnotatedWith((Class<? extends Annotation>) subType)
+                .stream()
+                .forEach(component -> registry.registerBeanDefinition(component,
+                    new DefaultBeanDefintion(component)));
+        }
+
+    }
+
+}

--- a/di/src/main/java/com/interface21/beans/factory/support/BeanScanner.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/BeanScanner.java
@@ -18,20 +18,25 @@ public class BeanScanner implements Scanner<Object> {
 
     @Override
     public void scan(Object... basePackage) {
-        Reflections reflections = new Reflections("com.interface21.context");
-        Set<Class<?>> annotatedClasses = reflections.getTypesAnnotatedWith(Component.class);
-        Set<Class<?>> annotations = annotatedClasses.stream()
-            .filter(Class::isAnnotation)
-            .collect(Collectors.toSet());
+        Set<Class<?>> componentAnnotations = scanAnnotationWithComponent();
 
         Reflections beanScanner = new Reflections(basePackage);
-        for (Class<?> subType : annotations) {
+        for (Class<?> subType : componentAnnotations) {
             beanScanner.getTypesAnnotatedWith((Class<? extends Annotation>) subType)
                 .stream()
                 .forEach(component -> registry.registerBeanDefinition(component,
                     new DefaultBeanDefintion(component)));
         }
 
+    }
+
+    private Set<Class<?>> scanAnnotationWithComponent() {
+        Reflections reflections = new Reflections("com.interface21.context");
+        Set<Class<?>> annotatedClasses = reflections.getTypesAnnotatedWith(Component.class);
+
+        return annotatedClasses.stream()
+            .filter(Class::isAnnotation)
+            .collect(Collectors.toSet());
     }
 
 }

--- a/di/src/main/java/com/interface21/beans/factory/support/DefaultListableBeanFactory.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/DefaultListableBeanFactory.java
@@ -1,36 +1,90 @@
 package com.interface21.beans.factory.support;
 
+import com.interface21.beans.BeanInstantiationException;
 import com.interface21.beans.factory.BeanFactory;
 import com.interface21.beans.factory.config.BeanDefinition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.interface21.beans.factory.support.injector.InjectorConsumer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class DefaultListableBeanFactory implements BeanFactory {
+public class DefaultListableBeanFactory implements BeanFactory, BeanDefinitionRegistry {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultListableBeanFactory.class);
 
     private final Map<String, BeanDefinition> beanDefinitionMap = new HashMap<>();
-
     private final Map<Class<?>, Object> singletonObjects = new HashMap<>();
 
     @Override
     public Set<Class<?>> getBeanClasses() {
-        return Set.of();
+        return beanDefinitionMap.entrySet()
+            .stream().map(entry -> entry.getValue().getType())
+            .collect(Collectors.toSet());
     }
 
     @Override
     public <T> T getBean(final Class<T> clazz) {
-        return null;
+        if (singletonObjects.containsKey(clazz)) {
+            return (T) singletonObjects.get(clazz);
+        }
+
+        Class<?> concreteClass = initializeAndRetrieve(clazz);
+
+        return (T) singletonObjects.get(concreteClass);
+    }
+
+    private <T> Class<?> initializeAndRetrieve(Class<T> clazz) {
+        beanInitialize(clazz, getBeanClasses());
+        Class<?> concreteClass = BeanFactoryUtils.findConcreteClass(clazz, getBeanClasses())
+            .orElse(null);
+        return concreteClass;
     }
 
     public void initialize() {
+        Set<Class<?>> definitions = getBeanClasses();
+        definitions
+            .forEach(
+                bean -> beanInitialize(bean, definitions)
+            );
+    }
+
+    private Object beanInitialize(Class<?> preInitializedBean, Set<Class<?>> definitions) {
+        Class<?> concreteClass = BeanFactoryUtils.findConcreteClass(preInitializedBean, definitions)
+            .orElseThrow(
+                () -> new BeanInstantiationException(preInitializedBean, "No class found"));
+        Object bean = singletonObjects.get(concreteClass.getName());
+
+        if (bean != null) {
+            return bean;
+        }
+
+        if (beanDefinitionMap.containsKey(concreteClass.getName())) {
+            BeanDefinition beanDefinition = beanDefinitionMap.get(concreteClass.getName());
+            InjectorConsumer<?> injector = beanDefinition.getInjector();
+            bean = injector.inject(this);
+            addBeanWithClass(concreteClass, bean);
+            return bean;
+        }
+
+        return null;
     }
 
     @Override
     public void clear() {
+        beanDefinitionMap.clear();
+        singletonObjects.clear();
+    }
+
+    @Override
+    public void registerBeanDefinition(Class<?> clazz, BeanDefinition beanDefinition) {
+        beanDefinitionMap.put(clazz.getName(), beanDefinition);
+    }
+
+    private void addBeanWithClass(Class<?> concreteClass, Object bean) {
+        singletonObjects.put(concreteClass, bean);
+
     }
 }

--- a/di/src/main/java/com/interface21/beans/factory/support/Scanner.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/Scanner.java
@@ -1,0 +1,6 @@
+package com.interface21.beans.factory.support;
+
+public interface Scanner<T> {
+
+    void scan(Object... basePackage);
+}

--- a/di/src/main/java/com/interface21/beans/factory/support/injector/ConstructorInjector.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/injector/ConstructorInjector.java
@@ -1,0 +1,31 @@
+package com.interface21.beans.factory.support.injector;
+
+import com.interface21.beans.BeanUtils;
+import com.interface21.beans.factory.BeanFactory;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+
+public class ConstructorInjector implements InjectorConsumer<Constructor<?>> {
+
+    private final Constructor<?> constructor;
+
+    public ConstructorInjector(Constructor<?> constructor) {
+        this.constructor = constructor;
+    }
+
+    @Override
+    public boolean support() {
+        return constructor != null;
+    }
+
+    @Override
+    public Object inject(BeanFactory beanFactory) {
+        Object[] params = Arrays.stream(constructor.getParameterTypes())
+            .map(param -> beanFactory.getBean(param))
+            .toArray();
+        Object bean = BeanUtils.instantiateClass(constructor, params);
+        return bean;
+    }
+
+
+}

--- a/di/src/main/java/com/interface21/beans/factory/support/injector/ConstructorInjector.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/injector/ConstructorInjector.java
@@ -2,6 +2,7 @@ package com.interface21.beans.factory.support.injector;
 
 import com.interface21.beans.BeanUtils;
 import com.interface21.beans.factory.BeanFactory;
+import com.interface21.beans.factory.annotation.Autowired;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 
@@ -15,7 +16,7 @@ public class ConstructorInjector implements InjectorConsumer<Constructor<?>> {
 
     @Override
     public boolean support() {
-        return constructor != null;
+        return constructor != null && constructor.isAnnotationPresent(Autowired.class);
     }
 
     @Override

--- a/di/src/main/java/com/interface21/beans/factory/support/injector/DefaultInjector.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/injector/DefaultInjector.java
@@ -1,0 +1,23 @@
+package com.interface21.beans.factory.support.injector;
+
+import com.interface21.beans.BeanUtils;
+import com.interface21.beans.factory.BeanFactory;
+
+public class DefaultInjector implements InjectorConsumer<Object> {
+
+    private final Class<?> clazz;
+
+    public DefaultInjector(Class<?> clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public boolean support() {
+        return true;
+    }
+
+    @Override
+    public Object inject(BeanFactory beanFactory) {
+        return BeanUtils.instantiate(clazz);
+    }
+}

--- a/di/src/main/java/com/interface21/beans/factory/support/injector/InjectorConsumer.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/injector/InjectorConsumer.java
@@ -1,0 +1,10 @@
+package com.interface21.beans.factory.support.injector;
+
+import com.interface21.beans.factory.BeanFactory;
+
+public interface InjectorConsumer<T> {
+
+    boolean support();
+
+    Object inject(BeanFactory beanFactory);
+}

--- a/di/src/main/java/com/interface21/beans/factory/support/injector/InjectorConsumerConfig.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/injector/InjectorConsumerConfig.java
@@ -10,7 +10,7 @@ import java.util.Set;
 public class InjectorConsumerConfig {
 
     public static List<InjectorConsumer<?>> injectorSuppliers(
-        Constructor<? extends Constructor> constructor, Set<Field> fields) {
+        Constructor<? extends Constructor> constructor) {
 
         return List.of(new ConstructorInjector(constructor));
 

--- a/di/src/main/java/com/interface21/beans/factory/support/injector/InjectorConsumerConfig.java
+++ b/di/src/main/java/com/interface21/beans/factory/support/injector/InjectorConsumerConfig.java
@@ -1,0 +1,18 @@
+package com.interface21.beans.factory.support.injector;
+
+import com.interface21.context.annotation.Configuration;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+
+@Configuration
+public class InjectorConsumerConfig {
+
+    public static List<InjectorConsumer<?>> injectorSuppliers(
+        Constructor<? extends Constructor> constructor, Set<Field> fields) {
+
+        return List.of(new ConstructorInjector(constructor));
+
+    }
+}

--- a/di/src/main/java/com/interface21/context/support/AnnotationConfigWebApplicationContext.java
+++ b/di/src/main/java/com/interface21/context/support/AnnotationConfigWebApplicationContext.java
@@ -1,6 +1,8 @@
 package com.interface21.context.support;
 
+import com.interface21.beans.factory.support.BeanScanner;
 import com.interface21.beans.factory.support.DefaultListableBeanFactory;
+import com.interface21.beans.factory.support.Scanner;
 import com.interface21.context.ApplicationContext;
 
 import java.util.Set;
@@ -11,15 +13,19 @@ public class AnnotationConfigWebApplicationContext implements ApplicationContext
 
     public AnnotationConfigWebApplicationContext(final String... basePackages) {
         this.beanFactory = new DefaultListableBeanFactory();
+        Scanner scanner = new BeanScanner(beanFactory);
+        scanner.scan(basePackages);
+
+        beanFactory.initialize();
     }
 
     @Override
     public <T> T getBean(final Class<T> clazz) {
-        return null;
+        return beanFactory.getBean(clazz);
     }
 
     @Override
     public Set<Class<?>> getBeanClasses() {
-        return Set.of();
+        return beanFactory.getBeanClasses();
     }
 }

--- a/di/src/test/java/com/interface21/beans/factory/support/BeanScannerTest.java
+++ b/di/src/test/java/com/interface21/beans/factory/support/BeanScannerTest.java
@@ -1,0 +1,42 @@
+package com.interface21.beans.factory.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.interface21.context.stereotype.Controller;
+import com.interface21.context.stereotype.Repository;
+import com.interface21.context.stereotype.Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import samples.JdbcSampleRepository;
+import samples.SampleController;
+import samples.SampleService;
+
+class BeanScannerTest {
+
+    private DefaultListableBeanFactory beanFactory;
+    private BeanScanner beanScanner;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        beanFactory = new DefaultListableBeanFactory();
+        beanScanner = new BeanScanner(beanFactory);
+        beanScanner.scan("samples");
+    }
+
+    @DisplayName("@Controller, @Service, @Repository, @Component 에노테이션이 붙은 클래스를 Registry에 등록합니다.")
+    @Test
+    void registerBeans(){
+        assertAll(
+            () -> assertThat(beanFactory.getBean(JdbcSampleRepository.class)).isInstanceOf(JdbcSampleRepository.class),
+            () -> assertThat(JdbcSampleRepository.class.isAnnotationPresent(Repository.class)).isTrue(),
+            () -> assertThat(beanFactory.getBean(SampleController.class)).isInstanceOf(SampleController.class),
+            () -> assertThat(SampleController.class.isAnnotationPresent(Controller.class)).isTrue(),
+            () -> assertThat(beanFactory.getBean(SampleService.class)).isInstanceOf(SampleService.class),
+            () -> assertThat(SampleService.class.isAnnotationPresent(Service.class)).isTrue()
+        );
+
+    }
+}

--- a/di/src/test/java/com/interface21/beans/factory/support/DefaultListableBeanFactoryTest.java
+++ b/di/src/test/java/com/interface21/beans/factory/support/DefaultListableBeanFactoryTest.java
@@ -13,14 +13,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class DefaultListableBeanFactoryTest {
 
-    private Reflections reflections;
     private DefaultListableBeanFactory beanFactory;
+    private BeanScanner beanScanner;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
     void setUp() {
-        reflections = new Reflections("samples");
         beanFactory = new DefaultListableBeanFactory();
+        beanScanner = new BeanScanner(beanFactory);
+        beanScanner.scan("samples");
         beanFactory.initialize();
     }
 
@@ -35,12 +36,5 @@ class DefaultListableBeanFactoryTest {
         assertNotNull(sampleService.getSampleRepository());
     }
 
-    @SuppressWarnings("unchecked")
-    private Set<Class<?>> getTypesAnnotatedWith(Class<? extends Annotation>... annotations) {
-        Set<Class<?>> beans = new HashSet<>();
-        for (Class<? extends Annotation> annotation : annotations) {
-            beans.addAll(reflections.getTypesAnnotatedWith(annotation));
-        }
-        return beans;
-    }
+
 }

--- a/di/src/test/java/com/interface21/beans/factory/support/injector/ConstructorInjectorTest.java
+++ b/di/src/test/java/com/interface21/beans/factory/support/injector/ConstructorInjectorTest.java
@@ -1,0 +1,36 @@
+package com.interface21.beans.factory.support.injector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.interface21.beans.factory.support.BeanScanner;
+import com.interface21.beans.factory.support.DefaultListableBeanFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import samples.SampleRepository;
+import samples.SampleService;
+
+class ConstructorInjectorTest {
+
+    private DefaultListableBeanFactory beanFactory;
+    private BeanScanner beanScanner;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        beanFactory = new DefaultListableBeanFactory();
+        beanScanner = new BeanScanner(beanFactory);
+        beanScanner.scan("samples");
+    }
+
+
+    @DisplayName("Constructor을 통해서 bean 주입을 합니다.")
+    @Test
+    void constructorInject(){
+        ConstructorInjector injector = new ConstructorInjector(SampleService.class.getConstructors()[0]);
+        SampleService service = (SampleService) injector.inject(beanFactory);
+
+        assertThat(service).isInstanceOf(SampleService.class);
+        assertThat(service.getSampleRepository()).isInstanceOf(SampleRepository.class);
+    }
+}

--- a/di/src/test/java/com/interface21/beans/factory/support/injector/DefaultInjectorTest.java
+++ b/di/src/test/java/com/interface21/beans/factory/support/injector/DefaultInjectorTest.java
@@ -1,0 +1,35 @@
+package com.interface21.beans.factory.support.injector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.interface21.beans.factory.support.BeanScanner;
+import com.interface21.beans.factory.support.DefaultListableBeanFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import samples.JdbcSampleRepository;
+import samples.SampleRepository;
+
+class DefaultInjectorTest {
+    private DefaultListableBeanFactory beanFactory;
+    private BeanScanner beanScanner;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        beanFactory = new DefaultListableBeanFactory();
+        beanScanner = new BeanScanner(beanFactory);
+        beanScanner.scan("samples");
+    }
+
+
+    @DisplayName("Constructor을 통해서 bean 주입을 합니다.")
+    @Test
+    void constructorInject(){
+        DefaultInjector injector = new DefaultInjector(JdbcSampleRepository.class);
+        JdbcSampleRepository repository = (JdbcSampleRepository) injector.inject(beanFactory);
+
+        assertThat(repository).isInstanceOf(JdbcSampleRepository.class);
+        assertThat(repository).isInstanceOf(SampleRepository.class);
+    }
+}

--- a/di/src/test/java/samples/JdbcSampleRepository.java
+++ b/di/src/test/java/samples/JdbcSampleRepository.java
@@ -2,15 +2,66 @@ package samples;
 
 import com.interface21.context.stereotype.Repository;
 
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
 import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
 
 @Repository
 public class JdbcSampleRepository implements SampleRepository {
 
     private final DataSource dataSource;
 
-    public JdbcSampleRepository(final DataSource dataSource) {
-        this.dataSource = dataSource;
+    public JdbcSampleRepository() {
+        this.dataSource = new DataSource() {
+            @Override
+            public Connection getConnection() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public Connection getConnection(String username, String password) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public PrintWriter getLogWriter() throws SQLException {
+                return null;
+            }
+
+            @Override
+            public void setLogWriter(PrintWriter out) throws SQLException {
+
+            }
+
+            @Override
+            public void setLoginTimeout(int seconds) throws SQLException {
+
+            }
+
+            @Override
+            public int getLoginTimeout() throws SQLException {
+                return 0;
+            }
+
+            @Override
+            public <T> T unwrap(Class<T> iface) throws SQLException {
+                return null;
+            }
+
+            @Override
+            public boolean isWrapperFor(Class<?> iface) throws SQLException {
+                return false;
+            }
+
+            @Override
+            public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+                return null;
+            }
+        };
     }
 
     public DataSource getDataSource() {

--- a/mvc/src/main/java/com/interface21/web/MyWebApplicationInitializer.java
+++ b/mvc/src/main/java/com/interface21/web/MyWebApplicationInitializer.java
@@ -20,7 +20,7 @@ public class MyWebApplicationInitializer implements WebApplicationInitializer {
 
         final var dispatcherServlet = new DispatcherServlet();
         dispatcherServlet.addHandlerMapping(new ManualHandlerMapping());
-        dispatcherServlet.addHandlerMapping(new AnnotationHandlerMapping("camp.nextstep.controller"));
+        dispatcherServlet.addHandlerMapping(new AnnotationHandlerMapping(applicationContext));
 
         dispatcherServlet.addHandlerAdapter(new ControllerHandlerAdapter());
         dispatcherServlet.addHandlerAdapter(new HandlerExecutionHandlerAdapter());

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMapping.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMapping.java
@@ -1,5 +1,6 @@
 package com.interface21.webmvc.servlet.mvc.tobe;
 
+import com.interface21.context.ApplicationContext;
 import com.interface21.web.bind.annotation.RequestMethod;
 import com.interface21.webmvc.servlet.mvc.HandlerMapping;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,17 +14,17 @@ public class AnnotationHandlerMapping implements HandlerMapping {
 
     private static final Logger log = LoggerFactory.getLogger(AnnotationHandlerMapping.class);
 
-    private final Object[] basePackage;
+    private final ApplicationContext applicationContext;
     private final Map<HandlerKey, HandlerExecution> handlerExecutions;
 
-    public AnnotationHandlerMapping(final Object... basePackage) {
-        this.basePackage = basePackage;
+    public AnnotationHandlerMapping(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
         this.handlerExecutions = new HashMap<>();
     }
 
     public void initialize() {
         final var controllerScanner = new ControllerScanner();
-        handlerExecutions.putAll(controllerScanner.scan(basePackage));
+        handlerExecutions.putAll(controllerScanner.handBeansToControllers(applicationContext));
         log.info("Initialized AnnotationHandlerMapping!");
     }
 

--- a/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/ControllerScanner.java
+++ b/mvc/src/main/java/com/interface21/webmvc/servlet/mvc/tobe/ControllerScanner.java
@@ -1,22 +1,25 @@
 package com.interface21.webmvc.servlet.mvc.tobe;
 
+import com.interface21.context.ApplicationContext;
 import com.interface21.context.stereotype.Controller;
 import com.interface21.core.util.ReflectionUtils;
 import com.interface21.web.bind.annotation.RequestMapping;
 import com.interface21.web.bind.annotation.RequestMethod;
 import com.interface21.web.method.support.HandlerMethodArgumentResolver;
-import com.interface21.webmvc.servlet.mvc.tobe.support.*;
-import org.reflections.Reflections;
-import org.reflections.scanners.Scanners;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.interface21.webmvc.servlet.mvc.tobe.support.HttpRequestArgumentResolver;
+import com.interface21.webmvc.servlet.mvc.tobe.support.HttpResponseArgumentResolver;
+import com.interface21.webmvc.servlet.mvc.tobe.support.ModelArgumentResolver;
+import com.interface21.webmvc.servlet.mvc.tobe.support.PathVariableArgumentResolver;
+import com.interface21.webmvc.servlet.mvc.tobe.support.RequestParamArgumentResolver;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ControllerScanner {
 
@@ -30,10 +33,15 @@ public class ControllerScanner {
         new ModelArgumentResolver()
     );
 
-    public Map<HandlerKey, HandlerExecution> scan(Object... basePackage) {
-        Reflections reflections = new Reflections(basePackage, Scanners.TypesAnnotated, Scanners.SubTypes, Scanners.MethodsAnnotated);
+    public Map<HandlerKey, HandlerExecution> handBeansToControllers(ApplicationContext applicationContext) {
+        Set<Class<?>> beans = applicationContext.getBeanClasses();
+
+        Set<Class<?>> controllers = beans.stream()
+            .filter(clazz -> clazz.isAnnotationPresent(Controller.class))
+            .collect(Collectors.toSet());
+
         final var handlers = new HashMap<HandlerKey, HandlerExecution>();
-        final var controllers = reflections.getTypesAnnotatedWith(Controller.class);
+
         for (Class<?> controller : controllers) {
             Object target = ReflectionUtils.newInstance(controller);
             addHandlerExecution(handlers, target, controller.getMethods());

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMappingTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/AnnotationHandlerMappingTest.java
@@ -1,5 +1,7 @@
 package com.interface21.webmvc.servlet.mvc.tobe;
 
+import com.interface21.context.ApplicationContext;
+import com.interface21.context.support.AnnotationConfigWebApplicationContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,7 +17,8 @@ class AnnotationHandlerMappingTest {
 
     @BeforeEach
     void setUp() {
-        handlerMapping = new AnnotationHandlerMapping("samples");
+        ApplicationContext applicationContext = new AnnotationConfigWebApplicationContext("samples");
+        handlerMapping = new AnnotationHandlerMapping(applicationContext);
         handlerMapping.initialize();
     }
 

--- a/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathVariableArgumentResolverTest.java
+++ b/mvc/src/test/java/com/interface21/webmvc/servlet/mvc/tobe/support/PathVariableArgumentResolverTest.java
@@ -44,7 +44,7 @@ class PathVariableArgumentResolverTest {
 
             Arguments.of(new MockHttpServletRequest("GET", "/pathVariable/user/50"),
                 new MethodParameter(mockIntPathVariableMethod, Integer.class, new Annotation[]{intAnnotation}, paramName),
-                "50")
+                50)
         );
     }
 }


### PR DESCRIPTION





안녕하세요, 동철님, 이번미션은 정말 재밌었네요!
제가 모르고 1단계와 2단계를 동시에 진행을 했는데 이렇게 리뷰 받아도 괜찮을까요??
요구사항이 부족한 부분은 말씀해주세요!~
이번 리뷰 잘 부탁드리겠습니다!~

## 테스트 

![image](https://github.com/user-attachments/assets/ed5eff4d-c9c1-4330-babc-f1a0678f5630)
![image](https://github.com/user-attachments/assets/3dbf81c6-4eab-451e-b0ee-5cfb1eedd573)


## 요구사항 정리
- [] 요구사항 1 - DefaultListableBeanFactoryTest 가 통과하게 만든다.
    - @Controller, @Service, @Repository를 스캔해서 클래스들을 가져온다. (BeanScanner)
      - 기능 
      - 조건 
    - @Autowired을 사용한 생성자를 이용해서 의존관계를 생성한다. (BeanFactory)
      - 기능
      - 조건
- [] 요구사항 2 - AnnotationMapping이 동작하도록 리팩터링한다.
    - BeanFactory와 BeanScanner를 잘 활용해서 동작하면 된다.
      
- [] 공통 요구사항
  - [] DefaultListableBean이 Bean 조립 즉, Injection을 책임으로 가진 구현체이다. 책임에 맞게 클래스 설계하라 
    - doResolveDependency(Dependency-descriptor, beanName)  (의존 관계에 대한 descriptor, bean 이름을 가지고 주입해준다.)
      - findAutowireCandidates(qualifier를 가지고 주입하게된다.)
      - ConstructorResolver를 통해 injectionPoint를 가지고 bean 주입을 하게된다. 
  - [] BeanScanner 는 Bean을 scan 만하는 책임을 가진다.
  - [] BeanDefinitionRegistry 에서 bean을 등록하는 책임을 가진다. (BeanDefinitionMap에 넣어준다. beanName, beanDefinition)
  - [] BeanDefinition은 instance 에 대한 정보를 담는다 + scope

## 구현 내용 정리
- 호출 순서
    - ApplicationContext -> DefaultListableBeanFactory(Scanner)
    - scaner 호출로 registry에 bean definition 등록
    - beanfactory.initialize로 객체들 definition에 맞게 구현체 생성
    - ApplicationContext 반환
- DefaultListableBean (BeanDefinitionRegistry 인터페이스, BeanFactory 인터페이스)
  - beanDefinitionMap (beanName, beanDefinition) 해쉬맵
  - singletonObjects (clazz, 구현체들) 해쉬맵
- 라이프사이클
  - REGISTRY 등록 
  - initialize 하면 Registry에서 BeanDefinition을 읽어서 instance 생성하는 방향이다.
    - injector를 확인해보고 다른 의존관계를 getBean으로 가져오는데 없다면 생성하면 된다. 
